### PR TITLE
Draft: log.Entry reusability

### DIFF
--- a/log/options.go
+++ b/log/options.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 )
 
+// Note the tests for these were moved into the root module of
+// this repo in order to import internal/testutils
+
 // Option is a function type that accepts an interface value and returns
 // an error. Use it to handle applying settings directly to the logger
 // implementation that are not covered by the Config.

--- a/logrus/logrus.go
+++ b/logrus/logrus.go
@@ -203,7 +203,7 @@ func (e *entry) Async() log.Entry {
 }
 
 func (e *entry) Caller(skip ...int) log.Entry {
-	if e == nil {
+	if e.notValid() {
 		return e
 	}
 
@@ -226,7 +226,7 @@ func (e *entry) Caller(skip ...int) log.Entry {
 }
 
 func (e *entry) WithError(errs ...error) log.Entry {
-	if len(errs) == 0 || e == nil {
+	if len(errs) == 0 || e.notValid() {
 		return e
 	}
 
@@ -256,7 +256,7 @@ func (e *entry) WithFields(fields map[string]interface{}) log.Entry {
 }
 
 func (e *entry) WithBool(key string, bls ...bool) log.Entry {
-	if e == nil || len(bls) == 0 {
+	if e.notValid() || len(bls) == 0 {
 		return e
 	}
 
@@ -268,7 +268,7 @@ func (e *entry) WithBool(key string, bls ...bool) log.Entry {
 }
 
 func (e *entry) WithDur(key string, durs ...time.Duration) log.Entry {
-	if e == nil || len(durs) == 0 {
+	if e.notValid() || len(durs) == 0 {
 		return e
 	}
 
@@ -280,7 +280,7 @@ func (e *entry) WithDur(key string, durs ...time.Duration) log.Entry {
 }
 
 func (e *entry) WithInt(key string, is ...int) log.Entry {
-	if e == nil || len(is) == 0 {
+	if e.notValid() || len(is) == 0 {
 		return e
 	}
 
@@ -292,7 +292,7 @@ func (e *entry) WithInt(key string, is ...int) log.Entry {
 }
 
 func (e *entry) WithUint(key string, us ...uint) log.Entry {
-	if e == nil || len(us) == 0 {
+	if e.notValid() || len(us) == 0 {
 		return e
 	}
 
@@ -304,7 +304,7 @@ func (e *entry) WithUint(key string, us ...uint) log.Entry {
 }
 
 func (e *entry) WithStr(key string, strs ...string) log.Entry {
-	if e == nil || len(strs) == 0 {
+	if e.notValid() || len(strs) == 0 {
 		return e
 	}
 
@@ -317,7 +317,7 @@ func (e *entry) WithStr(key string, strs ...string) log.Entry {
 }
 
 func (e *entry) WithTime(key string, ts ...time.Time) log.Entry {
-	if e == nil || len(ts) == 0 {
+	if e.notValid() || len(ts) == 0 {
 		return e
 	}
 
@@ -331,19 +331,30 @@ func (e *entry) WithTime(key string, ts ...time.Time) log.Entry {
 	return e.WithField(key, i)
 }
 
-func (e *entry) Trace() log.Entry { e.lvl = logrus.TraceLevel; return e }
-func (e *entry) Debug() log.Entry { e.lvl = logrus.DebugLevel; return e }
-func (e *entry) Info() log.Entry  { e.lvl = logrus.InfoLevel; return e }
-func (e *entry) Warn() log.Entry  { e.lvl = logrus.WarnLevel; return e }
-func (e *entry) Error() log.Entry { e.lvl = logrus.ErrorLevel; return e }
-func (e *entry) Panic() log.Entry { e.lvl = logrus.PanicLevel; return e }
-func (e *entry) Fatal() log.Entry { e.lvl = logrus.FatalLevel; return e }
+func (e *entry) Trace() log.Entry { return e.setLevel(logrus.TraceLevel) }
+func (e *entry) Debug() log.Entry { return e.setLevel(logrus.DebugLevel) }
+func (e *entry) Info() log.Entry  { return e.setLevel(logrus.InfoLevel) }
+func (e *entry) Warn() log.Entry  { return e.setLevel(logrus.WarnLevel) }
+func (e *entry) Error() log.Entry { return e.setLevel(logrus.ErrorLevel) }
+func (e *entry) Panic() log.Entry { return e.setLevel(logrus.PanicLevel) }
+func (e *entry) Fatal() log.Entry { return e.setLevel(logrus.FatalLevel) }
+
+func (e *entry) setLevel(lg logrus.Level) log.Entry {
+	if !e.notValid() {
+		e.lvl = lg
+	}
+	return e
+}
 
 func (e *entry) Msgf(format string, vals ...interface{}) {
 	e.Msg(fmt.Sprintf(format, vals...))
 }
 
 func (e *entry) Msg(msg string) {
+	if e.notValid() {
+		return
+	}
+
 	e.msg = msg
 
 	if !e.async {
@@ -352,7 +363,7 @@ func (e *entry) Msg(msg string) {
 }
 
 func (e *entry) Send() {
-	if e == nil || e.ent == nil {
+	if e.notValid() {
 		return
 	}
 
@@ -373,6 +384,10 @@ func (e *entry) Send() {
 	}
 
 	e.msg = ""
+}
+
+func (e *entry) notValid() bool {
+	return e == nil || e.ent == nil
 }
 
 // UnderlyingLogger implementation.

--- a/logrus/options.go
+++ b/logrus/options.go
@@ -1,0 +1,23 @@
+package logrus
+
+import (
+	"fmt"
+
+	"github.com/secureworks/logger/log"
+)
+
+// ReusableEntries returns a log.Option to be used with the logrus driver.
+// It instructs this driver to change the behavior of Send on the Entry interface
+// such that it can be reusable (called multiple times). Read the log package
+// interface documentation for more.
+func ReusableEntries() log.Option {
+	return func(i interface{}) error {
+		l, ok := i.(*logger)
+		if !ok {
+			return fmt.Errorf("log/logrus: Unexpected type passed to log option: %T", i)
+		}
+
+		l.reusableEntries = true
+		return nil
+	}
+}

--- a/zerolog/options.go
+++ b/zerolog/options.go
@@ -1,0 +1,23 @@
+package zerolog
+
+import (
+	"fmt"
+
+	"github.com/secureworks/logger/log"
+)
+
+// ReusableEntries returns a log.Option to be used with the zerolog driver.
+// It instructs this driver to change the behavior of Send on the Entry interface
+// such that it can be reusable (called multiple times). Read the log package
+// interface documentation for more.
+func ReusableEntries() log.Option {
+	return func(i interface{}) error {
+		l, ok := i.(*logger)
+		if !ok {
+			return fmt.Errorf("log/zerolog: Unexpected type passed to log option: %T", i)
+		}
+
+		l.reusableEntries = true
+		return nil
+	}
+}

--- a/zerolog/zcontext_entry.go
+++ b/zerolog/zcontext_entry.go
@@ -1,0 +1,256 @@
+package zerolog
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/secureworks/logger/log"
+)
+
+type zcontext struct {
+	zctx   zerolog.Context
+	caller []string
+	msg    string
+	async  bool
+	loglvl zerolog.Level
+	lvl    zerolog.Level
+}
+
+var _ log.Entry = (*zcontext)(nil)
+
+func (e *zcontext) Async() log.Entry {
+	if e.notValid() {
+		return e
+	}
+	e.async = !e.async
+	return e
+}
+
+func (e *zcontext) Caller(skip ...int) log.Entry {
+	if e.notValid() {
+		return e
+	}
+
+	sk := 1
+	if len(skip) > 0 {
+		sk += skip[0]
+	}
+
+	// Originally it was planned to use zerologs Caller implementation
+	// but the interface was changed during the design phase to allow the
+	// Caller to be called multiple times which zerolog won't do without
+	// adding dup fields.
+	_, file, line, ok := runtime.Caller(sk)
+	if !ok {
+		return e
+	}
+
+	// TODO(IB): Use zerolog.CallerMarshalFunc?
+	e.caller = append(e.caller, fmt.Sprintf("%s:%d", file, line))
+	return e
+}
+
+func (e *zcontext) WithError(errs ...error) log.Entry {
+	le := len(errs)
+	if e.notValid() || le == 0 {
+		return e
+	}
+
+	if le == 1 {
+		e.zctx = e.zctx.Err(errs[0])
+	} else {
+		e.zctx = e.zctx.Errs(zerolog.ErrorFieldName, errs)
+	}
+	return e
+}
+
+func (e *zcontext) WithField(key string, val interface{}) log.Entry {
+	if e.notValid() {
+		return e
+	}
+	e.zctx = e.zctx.Interface(key, val)
+	return e
+}
+
+func (e *zcontext) WithFields(fields map[string]interface{}) log.Entry {
+	if e.notValid() || len(fields) == 0 {
+		return e
+	}
+	e.zctx = e.zctx.Fields(fields)
+	return e
+}
+
+func (e *zcontext) WithBool(key string, bls ...bool) log.Entry {
+	lb := len(bls)
+	if e.notValid() || lb == 0 {
+		return e
+	}
+
+	if lb == 1 {
+		e.zctx = e.zctx.Bool(key, bls[0])
+	} else {
+		e.zctx = e.zctx.Bools(key, bls)
+	}
+	return e
+}
+
+func (e *zcontext) WithDur(key string, durs ...time.Duration) log.Entry {
+	ld := len(durs)
+	if e.notValid() || ld == 0 {
+		return e
+	}
+
+	if ld == 1 {
+		e.zctx = e.zctx.Dur(key, durs[0])
+	} else {
+		e.zctx = e.zctx.Durs(key, durs)
+	}
+	return e
+}
+
+func (e *zcontext) WithInt(key string, is ...int) log.Entry {
+	li := len(is)
+	if e.notValid() || li == 0 {
+		return e
+	}
+
+	if li == 1 {
+		e.zctx = e.zctx.Int(key, is[0])
+	} else {
+		e.zctx = e.zctx.Ints(key, is)
+	}
+	return e
+}
+
+func (e *zcontext) WithUint(key string, us ...uint) log.Entry {
+	lu := len(us)
+	if e.notValid() || lu == 0 {
+		return e
+	}
+
+	if lu == 1 {
+		e.zctx = e.zctx.Uint(key, us[0])
+	} else {
+		e.zctx = e.zctx.Uints(key, us)
+	}
+	return e
+}
+
+func (e *zcontext) WithStr(key string, strs ...string) log.Entry {
+	ls := len(strs)
+	if e.notValid() || ls == 0 {
+		return e
+	}
+
+	if ls == 1 {
+		e.zctx = e.zctx.Str(key, strs[0])
+	} else {
+		e.zctx = e.zctx.Strs(key, strs)
+	}
+	return e
+}
+
+func (e *zcontext) WithTime(key string, ts ...time.Time) log.Entry {
+	lt := len(ts)
+	if e.notValid() || lt == 0 {
+		return e
+	}
+
+	if lt == 1 {
+		e.zctx = e.zctx.Time(key, ts[0])
+	} else {
+		e.zctx = e.zctx.Times(key, ts)
+	}
+	return e
+}
+
+func (e *zcontext) Trace() log.Entry { return e.setLevel(zerolog.TraceLevel) }
+func (e *zcontext) Debug() log.Entry { return e.setLevel(zerolog.DebugLevel) }
+func (e *zcontext) Info() log.Entry  { return e.setLevel(zerolog.InfoLevel) }
+func (e *zcontext) Warn() log.Entry  { return e.setLevel(zerolog.WarnLevel) }
+func (e *zcontext) Error() log.Entry { return e.setLevel(zerolog.ErrorLevel) }
+func (e *zcontext) Panic() log.Entry { return e.setLevel(zerolog.PanicLevel) }
+func (e *zcontext) Fatal() log.Entry { return e.setLevel(zerolog.FatalLevel) }
+
+func (e *zcontext) Msgf(format string, vals ...interface{}) {
+	e.Msg(fmt.Sprintf(format, vals...))
+}
+
+func (e *zcontext) Msg(msg string) {
+	if e.notValid() {
+		return
+	}
+
+	e.msg = msg
+	if !e.async {
+		e.Send()
+	}
+}
+
+func (e *zcontext) Send() {
+	if !e.enabled() {
+		return
+	}
+
+	zl := e.zctx.Logger()
+	ent := zl.WithLevel(e.lvl)
+
+	if len(e.caller) > 0 {
+		ent = ent.Strs(log.CallerField, e.caller)
+	}
+
+	ent.Msg(e.msg)
+
+	// These are called by e.done here:
+	//   - https://github.com/rs/zerolog/blob/791ca15d999a97768ffd3b040116f9f5a772661a/event.go
+	//
+	// They are disabled however by our use of 'WithLevel'/'NoLevel', so we retain the
+	// functions here.
+	//
+	switch e.lvl {
+	case zerolog.PanicLevel:
+		panic(e.msg)
+	case zerolog.FatalLevel:
+		os.Exit(1)
+	}
+	e.msg = ""
+}
+
+// UnderlyingLogger implementation.
+
+func (e *zcontext) GetLogger() interface{} {
+	if e.notValid() {
+		return nil
+	}
+
+	return e.zctx
+}
+
+func (e *zcontext) SetLogger(l interface{}) {
+	if zctx, ok := l.(zerolog.Context); ok && !e.notValid() {
+		e.zctx = zctx
+	}
+}
+
+// Zerolog-specific methods.
+
+// Entry utility functions.
+
+func (e *zcontext) notValid() bool {
+	return e == nil
+}
+
+func (e *zcontext) enabled() bool {
+	return !e.notValid() && e.lvl >= e.loglvl
+}
+
+func (e *zcontext) setLevel(lvl zerolog.Level) log.Entry {
+	if e.notValid() {
+		return e
+	}
+	e.lvl = lvl
+	return e
+}

--- a/zerolog/ztype_go118.go.bak
+++ b/zerolog/ztype_go118.go.bak
@@ -1,0 +1,35 @@
+//go:build go1.18
+// This file is straight up not allowed despite build flag
+// https://github.com/golang/go/issues/52880
+
+package zerolog
+
+import "github.com/rs/zerolog"
+
+// Generics continue to be a great fit for this entire repo
+// would likely cut code by more than half, the below interface
+// just doesn't work
+// type zType interface {
+//	 Str(string) zType
+//	 // ...
+// }
+//
+// For pre 1.18 another sub type that delegates to a zerolog.Entry
+// or zerolog.Context would work, though it wouldn't result in much
+// less code than zcontext_entry.go already has. Leaving it
+// as is with a copy is easier to move to generics later.
+
+type zUnion interface {
+	*zerolog.Event | zerolog.Context
+}
+
+type zType[Z zUnion] interface {
+	Err(error) Z
+	Str(string) Z
+	Strs(string, []string) Z
+	// ... all other methods they have in common that we want to use
+	// then have *entry use zType
+}
+
+var _ zType[*zerolog.Event]
+var _ zType[zerolog.Context]


### PR DESCRIPTION
Please read the entirety of this PR comment before proceeding.
Note this is a draft PR, some local tests were made but not committed to avoid loss of time if these changes are not desired relative to the wanted outcome. It is to spur discussion, not to be merged as is, yet.

## Changes
- Allows users of zerolog/logrus drivers to set a behavior of the log.Entry interface type that has always made it clear that the top level interface does not enforce or define a behavior if called multiple times. This change uses a log.Option in each respective package instead of a log.Config change in order to avoid changing the higher level log package, but to also leave it as an option for drivers, rather than a requirement.
- Keeps backwards compatibility with existing interfaces, no v2 of package needed.
- logrus driver, if set to not reuse entries, becomes a noop if already sent, rather than panicing if misused.

## Tradeoffs
- Introducing a new type, regardless of similarities with log.Entry would result in a breaking change to the higher level log package and interface, therefore requiring a v2. Unless the new type was only exported via an optional interface, but then this becomes more verbose to use.
- Code duplication in zerolog version (of the existing *entry type), check ztype_go118 for details. The TLDR though is that pre1.18 interfaces were not good enough to interchange between Entries and Contexts from zerolog, there was a TODO about this some time ago but was removed before this code/repo was moved to github _and_ before generics were accepted into Go.
- It was always documented that a log.Entry was the type for _individual_ entries to spur canonical log lines, and generally discourage log spam. If new code is now written that expects an entry to be reusable but is given one that isn't, it will "not behave as expected". An assertable interface such as the one below could be added and a helper in the log package so code can check this behavior without knowledge of the underlying driver or settings. This would still be backwards compatible from an interface signature standpoint.
```go
// Or Reuser/Reuse, Reuser/Reusable to make it more idiomatic
type Reusable interface {
	Reusable() bool
}
```
- Or, to keep log.Entry as "single"/individual entries we add a new type, which would cause the breaking changes mentioned above but might be clearer to users. The amount of code would change little, given the need for generics to cut down on much of what is already here.