### PR TITLE
Avoid nil pointer de-reference panic when accidentally passing nil into WithError() on zerolog

### DIFF
--- a/zerolog/zerolog.go
+++ b/zerolog/zerolog.go
@@ -5,6 +5,7 @@
 package zerolog
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,10 @@ import (
 
 	"github.com/secureworks/logger/internal/common"
 	"github.com/secureworks/logger/log"
+)
+
+var (
+	nilError = errors.New("nil passed in to WithError")
 )
 
 // Register logger.
@@ -279,8 +284,16 @@ func (e *entry) WithError(errs ...error) log.Entry {
 	}
 
 	if le == 1 {
+		if errs[0] == nil {
+			errs[0] = nilError
+		}
 		e.ent = e.ent.Err(errs[0])
 	} else {
+		for idx, err := range errs {
+			if err == nil {
+				errs[idx] = nilError
+			}
+		}
 		e.ent = e.ent.Errs(zerolog.ErrorFieldName, errs)
 	}
 	return e


### PR DESCRIPTION
We had a case where someone accidentally passed nil as the error value into WithError. This caused a panic with in zerolog Err() method.
 