### PR TITLE
Add support for passing responses to middleware

### DIFF
--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/VerticalOps/fakesentry"
-	"github.com/getsentry/sentry-go"
 
 	"github.com/secureworks/logger/log"
 )
@@ -42,9 +41,9 @@ func NewConfigWithBuffer(t *testing.T, logLevel log.Level) (*log.Config, *bytes.
 
 // BindSentryClient attaches a Sentry server transport (from fake
 // Sentry) to the Sentry SDK's CurrentHub .It assumes that a logger has
-// been instantiated, which initializes the Sentry SDK.
-// Note this is data-race free but not race-condition free on the Sentry Hub.
-// Use with caution from multiple goroutines.
+// been instantiated, which initializes the Sentry SDK. Note: this is
+// data-race free but not race-condition free on the Sentry Hub. Use
+// with caution from multiple goroutines.
 func BindSentryClient(t *testing.T, tcp *http.Transport) {
 	t.Helper()
 
@@ -184,7 +183,8 @@ func AssertNotNil(t *testing.T, object interface{}) {
 	assertNility(t, object, false)
 }
 
-// AssertStringContains is a semantic test assertion for partial string matching.
+// AssertStringContains is a semantic test assertion for partial string
+// matching.
 func AssertStringContains(t *testing.T, expectedContained string, actualContaining string) {
 	t.Helper()
 	if !strings.Contains(actualContaining, expectedContained) {
@@ -194,6 +194,22 @@ func AssertStringContains(t *testing.T, expectedContained string, actualContaini
 			strings.Trim(actualContaining, "\n"),
 		)
 	}
+}
+
+// AssertNotPanics is a semantic test assertion that a function does not
+// panic.
+func AssertNotPanics(t *testing.T, fn func()) {
+	t.Helper()
+
+	didPanic := true
+	defer func() {
+		if didPanic {
+			t.Errorf("did panic")
+		}
+	}()
+
+	fn()
+	didPanic = false
 }
 
 // NOTE(PH): does not handle bytes well, update if we need to check

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -100,9 +101,24 @@ func TestHTTPRequestLogAttributes(t *testing.T) {
 					return
 				},
 			},
+			SyntheticsResponse: map[string]func(w middleware.ResponseWriter) string{
+				"http.status_code": func(w middleware.ResponseWriter) string {
+					return fmt.Sprint(w.StatusCode())
+				},
+				"http.body_size": func(w middleware.ResponseWriter) string {
+					return fmt.Sprintf("%dB", w.BodySize())
+				},
+				// Should fail.
+				"res.other": func(w middleware.ResponseWriter) (val string) {
+					if resID := w.Header().Get("X-Response-Id"); resID != "" {
+						val = resID
+					}
+					return
+				},
+			},
 		},
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"OK"}`))
 		}),
 	)
 	testutils.AssertEqual(t, http.StatusOK, resp.Code)
@@ -115,9 +131,12 @@ func TestHTTPRequestLogAttributes(t *testing.T) {
 	testutils.AssertEqual(t, cID, entry.StringField("x-tenant-ctx"))
 	testutils.AssertEqual(t, env, entry.StringField("x-environment"))
 	testutils.AssertEqual(t, uID, entry.StringField("req.uuid"))
+	testutils.AssertEqual(t, "200", entry.StringField("http.status_code"))
+	testutils.AssertEqual(t, "15B", entry.StringField("http.body_size"))
 
 	testutils.AssertFalse(t, entry.HasField("x-other"))
 	testutils.AssertFalse(t, entry.HasField("req.other"))
+	testutils.AssertFalse(t, entry.HasField("res.other"))
 }
 
 func TestHTTPRequestMiddlewarePanic(t *testing.T) {

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -125,10 +125,7 @@ type flusherResponseWriter struct {
 }
 
 func (w *flusherResponseWriter) Flush() {
-	if wc, ok := w.ResponseWriter.(interface{ HasBeenWrittenTo() bool }); ok && !wc.HasBeenWrittenTo() {
-		w.WriteHeader(http.StatusOK)
-	}
-	w.Flusher.Flush()
+	flush(w.Flusher, w.ResponseWriter)
 }
 
 type hijackerResponseWriter struct {
@@ -138,13 +135,7 @@ type hijackerResponseWriter struct {
 }
 
 func (w *hijackerResponseWriter) Flush() {
-	if w.Flusher == nil {
-		return
-	}
-	if wc, ok := w.ResponseWriter.(interface{ HasBeenWrittenTo() bool }); ok && !wc.HasBeenWrittenTo() {
-		w.WriteHeader(http.StatusOK)
-	}
-	w.Flusher.Flush()
+	flush(w.Flusher, w.ResponseWriter)
 }
 
 type pusherResponseWriter struct {
@@ -154,11 +145,15 @@ type pusherResponseWriter struct {
 }
 
 func (w *pusherResponseWriter) Flush() {
-	if w.Flusher == nil {
+	flush(w.Flusher, w.ResponseWriter)
+}
+
+func flush(flusher http.Flusher, w ResponseWriter) {
+	if flusher == nil {
 		return
 	}
-	if wc, ok := w.ResponseWriter.(interface{ HasBeenWrittenTo() bool }); ok && !wc.HasBeenWrittenTo() {
+	if wc, ok := w.(interface{ HasBeenWrittenTo() bool }); ok && !wc.HasBeenWrittenTo() {
 		w.WriteHeader(http.StatusOK)
 	}
-	w.Flusher.Flush()
+	flusher.Flush()
 }

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// ResponseWriter implements an interface that allows logging middleware
+// access to standard information about the underlying response that is
+// unattainable in the default http.ResponseWriter interface.
+//
+// In order not to break basic net/http interfaces that are commonly
+// implemented (http.Flusher and http.Hijacker), we handle these as
+// well, passing to the underlying response writer if it implements them
+// in turn. This writer does not support http.Pusher.
+//
+// One issue is that our implementation fulfills both http.Flusher and
+// http.Hijacker regardless of whether they do. Often calling code will
+// assert against an interface to check if the http. ResponseWriter may
+// also implement these: this can lead to false positives when using
+// this library.
+//
+// Does not hold a separate response body buffer. Log in the application
+// for this sort of data.
+type ResponseWriter interface {
+	http.ResponseWriter
+
+	// StatusCode returns the status code of the response. If not written
+	// yet, this returns 0.
+	StatusCode() int
+
+	// Status returns the HTTP/1.1-standard name for the status code. If
+	// not written yet, this returns "".
+	Status() string
+
+	// BodySize returns the size of the response body.
+	BodySize() int
+}
+
+// NewResponseWriter returns a logging-specific ResponseWriter that
+// wraps an http.ResponseWriter, for use in logging middleware.
+func NewResponseWriter(w http.ResponseWriter) ResponseWriter {
+	return &responseWriter{ResponseWriter: w}
+}
+
+// responseWriter implements the ResponseWriter interface.
+type responseWriter struct {
+	http.ResponseWriter
+
+	statusCode int
+	status     string
+	bodySize   int
+}
+
+// Getters.
+
+func (w *responseWriter) StatusCode() int {
+	return w.statusCode
+}
+
+func (w *responseWriter) Status() string {
+	return w.status
+}
+
+func (w *responseWriter) BodySize() int {
+	return w.bodySize
+}
+
+// HasBeenWrittenTo returns whether the ResponseWriter has been written to.
+func (w *responseWriter) HasBeenWrittenTo() bool {
+	return w.statusCode != 0
+}
+
+// Implement (wrap) http.ResponseWriter.
+
+func (w *responseWriter) WriteHeader(code int) {
+	if w.HasBeenWrittenTo() {
+		return
+	}
+	w.statusCode = code
+	w.status = fmt.Sprintf("%d %s", code, http.StatusText(code))
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseWriter) Write(b []byte) (int, error) {
+	if !w.HasBeenWrittenTo() {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(b)
+	w.bodySize += n
+	return n, err
+}
+
+// Implement http.Flusher and http.Hijacker.
+
+func (w *responseWriter) Flush() {
+	flusher, ok := w.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
+	}
+	if !w.HasBeenWrittenTo() {
+		w.WriteHeader(http.StatusOK)
+	}
+	flusher.Flush()
+}
+
+func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("the underlying ResponseWriter does not implement http.Hijacker")
+	}
+	return hijacker.Hijack()
+}

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -1,9 +1,7 @@
 package middleware
 
 import (
-	"bufio"
 	"fmt"
-	"net"
 	"net/http"
 )
 
@@ -149,10 +147,6 @@ func (w *hijackerResponseWriter) Flush() {
 	w.Flusher.Flush()
 }
 
-func (w *hijackerResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return w.Hijacker.Hijack()
-}
-
 type pusherResponseWriter struct {
 	ResponseWriter
 	http.Pusher
@@ -167,8 +161,4 @@ func (w *pusherResponseWriter) Flush() {
 		w.WriteHeader(http.StatusOK)
 	}
 	w.Flusher.Flush()
-}
-
-func (w *pusherResponseWriter) Push(target string, opts *http.PushOptions) error {
-	return w.Pusher.Push(target, opts)
 }

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -12,17 +12,18 @@ import (
 // unattainable in the default http.ResponseWriter interface.
 //
 // In order not to break basic net/http interfaces that are commonly
-// implemented (http.Flusher, http.Hijacker http.Pusher), we handle
+// implemented (http.Flusher, http.Hijacker, and http.Pusher), we handle
 // these as well, passing to the underlying response writer if it
 // implements them in turn.
 //
 // One issue is that the available implementations will always fulfill
-// http.Flusher, even when only http.Hijacker or http.Pusher is
-// implemented by the underlying response writer. While this mirrors the
-// most common implementations (the standard HTTP/1.1 and HTTP/2
-// response writers, eg), it may lead to false positive http.Flusher
-// type assertions. Since an unimplemented call to Flush is a no-op,
-// this can be regarded as a minor issue.
+// http.Flusher if any of the above "alternate" interfaces is
+// implemented. Even when the underlying response writer is only
+// http.Hijacker or http.Pusher, the wrapper implements http.Flusher.
+// While this mirrors the most common types (the standard HTTP/1.1 and
+// HTTP/2 response writers, eg, all implement flusher), it may lead to
+// false positive http.Flusher type assertions. Since an unimplemented
+// call to Flush is a no-op, this can be regarded as a minor issue.
 //
 // Does not hold a separate response body buffer. Log in the application
 // for this sort of data.

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -18,10 +18,10 @@ import (
 // in turn. This writer does not support http.Pusher.
 //
 // One issue is that our implementation fulfills both http.Flusher and
-// http.Hijacker regardless of whether they do. Often calling code will
-// assert against an interface to check if the http. ResponseWriter may
-// also implement these: this can lead to false positives when using
-// this library.
+// http.Hijacker regardless of whether the underlying response writer
+// does. Often, calling code will assert against an interface to check
+// if an http.ResponseWriter may also implement these: this can lead to
+// false positives when using this library.
 //
 // Does not hold a separate response body buffer. Log in the application
 // for this sort of data.
@@ -54,6 +54,8 @@ type responseWriter struct {
 	status     string
 	bodySize   int
 }
+
+var _ http.ResponseWriter = (*responseWriter)(nil)
 
 // Getters.
 

--- a/middleware/response_writer_test.go
+++ b/middleware/response_writer_test.go
@@ -1,0 +1,1 @@
+package middleware

--- a/middleware/response_writer_test.go
+++ b/middleware/response_writer_test.go
@@ -1,1 +1,189 @@
-package middleware
+package middleware_test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/secureworks/logger/internal/testutils"
+	"github.com/secureworks/logger/middleware"
+)
+
+type mockRW struct {
+	StatusCode int
+	Buffer     *bytes.Buffer
+	Err        error
+	Hdr        http.Header
+}
+
+func (w *mockRW) Write(byt []byte) (int, error) {
+	if w.Err != nil {
+		return 1, w.Err
+	}
+	return w.Buffer.Write(byt)
+}
+func (w *mockRW) WriteHeader(statusCode int) { w.StatusCode = statusCode }
+
+func (w *mockRW) Header() http.Header { return w.Hdr }
+
+type mockHijackerFlusher struct {
+	CalledFlush  bool
+	CalledHijack bool
+}
+
+func (w *mockHijackerFlusher) Write(_ []byte) (int, error) { return 0, nil }
+
+func (w *mockHijackerFlusher) WriteHeader(_ int) {}
+
+func (w *mockHijackerFlusher) Header() http.Header { return http.Header{} }
+
+func (w *mockHijackerFlusher) Flush() { w.CalledFlush = true }
+
+func (w *mockHijackerFlusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.CalledHijack = true
+	return nil, nil, nil
+}
+
+func TestResponseWriter(t *testing.T) {
+	t.Run("passes Write through to underlying response writer", func(t *testing.T) {
+		mock := &mockRW{Buffer: new(bytes.Buffer)}
+		w := middleware.NewResponseWriter(mock)
+
+		var n int
+		var err error
+
+		n, err = w.Write([]byte(`{"example":`))
+		testutils.AssertNil(t, err)
+		testutils.AssertEqual(t, 11, n)
+		n, err = w.Write([]byte(`true}`))
+		testutils.AssertNil(t, err)
+		testutils.AssertEqual(t, 5, n)
+
+		testutils.AssertEqual(t, `{"example":true}`, mock.Buffer.String())
+		testutils.AssertEqual(t, 200, mock.StatusCode)
+	})
+
+	t.Run("passes WriteHeader through to underlying response writer", func(t *testing.T) {
+		mock := &mockRW{Buffer: new(bytes.Buffer)}
+		w := middleware.NewResponseWriter(mock)
+
+		w.WriteHeader(501)
+		testutils.AssertEqual(t, 501, mock.StatusCode)
+	})
+
+	t.Run("returns underlying writer state", func(t *testing.T) {
+		mock := &mockRW{Err: errors.New("io issue"), Hdr: http.Header{"X-Example": []string{"true"}}}
+		w := middleware.NewResponseWriter(mock)
+
+		_, err := w.Write([]byte(`!!!`))
+		testutils.AssertNotNil(t, err)
+
+		testutils.AssertEqual(t, w.Header().Get("X-Example"), "true")
+	})
+}
+
+func TestResponseWriter_StatusCode(t *testing.T) {
+	t.Run("empty by default", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		testutils.AssertEqual(t, 0, w.StatusCode())
+	})
+
+	t.Run("written too when writing header", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		w.WriteHeader(404)
+		testutils.AssertEqual(t, 404, w.StatusCode())
+	})
+
+	t.Run("written too when writing", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		w.Write([]byte(`{"example":true}`))
+		testutils.AssertEqual(t, 200, w.StatusCode())
+	})
+}
+
+func TestResponseWriter_Status(t *testing.T) {
+	t.Run("empty by default", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		testutils.AssertEqual(t, "", w.Status())
+	})
+
+	t.Run("written too when writing header", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		w.WriteHeader(404)
+		testutils.AssertEqual(t, "404 Not Found", w.Status())
+	})
+
+	t.Run("written too when writing", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		w.Write([]byte(`{"example":true}`))
+		testutils.AssertEqual(t, "200 OK", w.Status())
+	})
+}
+
+func TestResponseWriter_BodySize(t *testing.T) {
+	t.Run("empty by default", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		testutils.AssertEqual(t, 0, w.BodySize())
+	})
+
+	t.Run("written too when writing", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		w.Write([]byte(`{"example":`))
+		w.Write([]byte(`true}`))
+		testutils.AssertEqual(t, 16, w.BodySize())
+	})
+}
+
+func TestResponseWriter_Flush(t *testing.T) {
+	t.Run("is a no-op when underlying response writer does not implement", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		flusher, _ := w.(http.Flusher)
+		assertNotPanics(t, func() { flusher.Flush() })
+	})
+
+	t.Run("when implemented, passes through to underlying response writer", func(t *testing.T) {
+		mock := &mockHijackerFlusher{}
+		w := middleware.NewResponseWriter(mock)
+		flusher, _ := w.(http.Flusher)
+		flusher.Flush()
+		testutils.AssertTrue(t, mock.CalledFlush)
+	})
+}
+
+func TestResponseWriter_Hijack(t *testing.T) {
+	t.Run("returns an error when underlying response writer does not implement", func(t *testing.T) {
+		w := middleware.NewResponseWriter(&mockRW{Buffer: new(bytes.Buffer)})
+		hijacker, _ := w.(http.Hijacker)
+		assertNotPanics(t, func() {
+			conn, rw, err := hijacker.Hijack()
+			testutils.AssertNil(t, conn)
+			testutils.AssertNil(t, rw)
+			testutils.AssertEqual(t, err.Error(), "the underlying ResponseWriter does not implement http.Hijacker")
+		})
+	})
+
+	t.Run("when implemented, passes through to underlying response writer", func(t *testing.T) {
+		mock := &mockHijackerFlusher{}
+		w := middleware.NewResponseWriter(mock)
+		hijacker, _ := w.(http.Hijacker)
+		_, _, _ = hijacker.Hijack() // TODO(PH): IDK, maybe should check these?
+		testutils.AssertTrue(t, mock.CalledHijack)
+	})
+}
+
+func assertNotPanics(t *testing.T, fn func()) {
+	t.Helper()
+
+	didPanic := true
+	defer func() {
+		if didPanic {
+			t.Errorf("did panic")
+		}
+	}()
+
+	fn()
+	didPanic = false
+}

--- a/middleware/response_writer_test.go
+++ b/middleware/response_writer_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -178,8 +177,7 @@ func TestResponseWriter_Flush(t *testing.T) {
 	t.Run("is a no-op when underlying alt response writer does not implement", func(t *testing.T) {
 		w := middleware.NewResponseWriter(&mockHijackerOnly{})
 		flusher, ok := w.(http.Flusher)
-		fmt.Printf("%T\n", w)
-		fmt.Println(flusher, ok)
+		testutils.AssertTrue(t, ok)
 		assertNotPanics(t, func() { flusher.Flush() })
 	})
 


### PR DESCRIPTION
Adds a wrapper to the server's ResponseWriter to allow us to capture the necessary logging information. Also adds a backwards-compatible for adding log fields for information gleaned from the ResponseWriter.

Close #10.