### PR TITLE
Simplify middleware; use DataDog field names by default

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -134,23 +134,30 @@ const (
 
 	// ReqRemoteAddr is a key for Logger data concerning HTTP request
 	// logging.
-	ReqRemoteAddr = "http_remote_addr"
+	ReqRemoteAddr = "http.remote_addr"
+
+	// ReqID is a key for Logger data concerning HTTP request logging.
+	ReqID = "http.request_id"
+
+	// ResStatusCode is a key for Logger data concerning HTTP request
+	// logging.
+	ResStatusCode = "http.status_code"
 
 	// PanicStack is a key for Logger data concerning errors and stack
 	// traces.
-	PanicStack = "panic_stack"
+	PanicStack = "panic.stack"
 
 	// PanicValue is a key for Logger data concerning errors and stack
 	// traces.
-	PanicValue = "panic_value"
+	PanicValue = "panic.value"
 
 	// CallerField is a key for Logger data concerning errors and stack
 	// traces.
-	CallerField = "caller"
+	CallerField = "error.caller"
 
 	// StackField is a key for Logger data concerning errors and stack
 	// traces.
-	StackField = "stack"
+	StackField = "error.stack"
 )
 
 // Unified interface definitions.

--- a/log/log.go
+++ b/log/log.go
@@ -124,13 +124,13 @@ func (l LoggerFormat) IsValid() bool {
 const (
 	// ReqDuration is a key for Logger data concerning HTTP request
 	// logging.
-	ReqDuration = "request_duration"
+	ReqDuration = "duration"
 
 	// ReqPath is a key for Logger data concerning HTTP request logging.
-	ReqPath = "http_path"
+	ReqPath = "http.url_details.path"
 
 	// ReqMethod is a key for Logger data concerning HTTP request logging.
-	ReqMethod = "http_method"
+	ReqMethod = "http.method"
 
 	// ReqRemoteAddr is a key for Logger data concerning HTTP request
 	// logging.

--- a/log/log.go
+++ b/log/log.go
@@ -122,42 +122,62 @@ func (l LoggerFormat) IsValid() bool {
 // regularizing them we can make better assumptions about where to find
 // and extract them.
 const (
-	// ReqDuration is a key for Logger data concerning HTTP request
-	// logging.
+	// ReqDuration is a standard field name for commonly logged data that
+	// can help logs to be more readable. It is marks the duration of some
+	// task. It is a DataDog default standard attribute.
 	ReqDuration = "duration"
 
-	// ReqPath is a key for Logger data concerning HTTP request logging.
+	// ReqPath is a standard field name for commonly logged data that can
+	// help logs to be more readable. It marks the path of the request that
+	// is being logged. It is a DataDog default standard attribute.
 	ReqPath = "http.url_details.path"
 
-	// ReqMethod is a key for Logger data concerning HTTP request logging.
+	// ReqMethod is a standard field name for commonly logged data that can
+	// help logs to be more readable. It marks the method of the request
+	// that is being logged. It is a DataDog default standard attribute.
 	ReqMethod = "http.method"
 
-	// ReqRemoteAddr is a key for Logger data concerning HTTP request
-	// logging.
+	// ReqRemoteAddr is a standard field name for commonly logged data that
+	// can help logs to be more readable. It marks the IP address of the
+	// client that made the request that is being logged.
 	ReqRemoteAddr = "http.remote_addr"
 
-	// ReqID is a key for Logger data concerning HTTP request logging.
+	// ReqID is a standard field name for commonly logged data that can help
+	// logs to be more readable. It marks the unique ID of the request that
+	// is being logged. It is a DataDog default standard attribute.
 	ReqID = "http.request_id"
 
-	// ResStatusCode is a key for Logger data concerning HTTP request
-	// logging.
+	// ResStatusCode is a standard field name for commonly logged data that
+	// can help logs to be more readable. It marks the status of the
+	// response the server has generated for the request that is being
+	// logged. It is a DataDog default standard attribute.
 	ResStatusCode = "http.status_code"
 
-	// PanicStack is a key for Logger data concerning errors and stack
-	// traces.
-	PanicStack = "panic.stack"
+	// StackField is a standard field name for commonly logged data that can
+	// help logs to be more readable. It marks the error stack trace for the
+	// error that is being logged. It is a DataDog default standard
+	// attribute.
+	StackField = "error.stack"
 
-	// PanicValue is a key for Logger data concerning errors and stack
-	// traces.
+	// PanicValue is a standard field name for commonly logged data that can
+	// help logs to be more readable. It marks the message for the panic
+	// that is being logged.
 	PanicValue = "panic.value"
 
-	// CallerField is a key for Logger data concerning errors and stack
-	// traces.
-	CallerField = "error.caller"
+	// PanicStack is a standard field name for commonly logged data that can
+	// help logs to be more readable. It marks the stack trace for the panic
+	// that is being logged.
+	PanicStack = "panic.stack"
 
-	// StackField is a key for Logger data concerning errors and stack
-	// traces.
-	StackField = "error.stack"
+	// CallerField is a standard field name for commonly logged data that
+	// can help logs to be more readable. It marks when the logger
+	// attaches a specific stack frame to the log.
+	CallerField = "caller"
+
+	// LoggerVersionField is a standard field name for commonly logged data
+	// that can help logs to be more readable. It marks the current logger
+	// version.
+	LoggerVersionField = "logger.version"
 )
 
 // Unified interface definitions.

--- a/middleware/go.mod
+++ b/middleware/go.mod
@@ -8,3 +8,8 @@ require (
 	github.com/secureworks/logger/log v1.0.0
 	github.com/secureworks/logger/testlogger v1.0.0
 )
+
+replace (
+	github.com/secureworks/logger/log => ../log
+	github.com/secureworks/logger/internal => ../internal
+)

--- a/middleware/go.mod
+++ b/middleware/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/secureworks/logger/testlogger v1.0.0
 )
 
+// FIXME(PH): remove before v2 released.
 replace (
 	github.com/secureworks/logger/log => ../log
 	github.com/secureworks/logger/internal => ../internal

--- a/middleware/response_writer_test.go
+++ b/middleware/response_writer_test.go
@@ -178,7 +178,7 @@ func TestResponseWriter_Flush(t *testing.T) {
 		w := middleware.NewResponseWriter(&mockHijackerOnly{})
 		flusher, ok := w.(http.Flusher)
 		testutils.AssertTrue(t, ok)
-		assertNotPanics(t, func() { flusher.Flush() })
+		testutils.AssertNotPanics(t, func() { flusher.Flush() })
 	})
 
 	t.Run("when implemented, passes through to underlying response writer", func(t *testing.T) {
@@ -228,18 +228,4 @@ func TestResponseWriter_Pusher(t *testing.T) {
 		_ = pusher.Push("", nil) // TODO(PH): IDK, maybe should check these?
 		testutils.AssertTrue(t, mock.CalledPush)
 	})
-}
-
-func assertNotPanics(t *testing.T, fn func()) {
-	t.Helper()
-
-	didPanic := true
-	defer func() {
-		if didPanic {
-			t.Errorf("did panic")
-		}
-	}()
-
-	fn()
-	didPanic = false
 }


### PR DESCRIPTION
- Switches to using DataDog default field names where available. All things being equal, this means more users get DD logging integration out of the box.
- Simplifies the logging middleware interface in a big way to allow for both a standard / default set of fields and any custom field setup you want.

Resolves #9.