### PR TITLE
Fix nil panic in marshaler

### DIFF
--- a/internal/common/stack_trace.go
+++ b/internal/common/stack_trace.go
@@ -37,6 +37,8 @@ func (st stackTracer) StackTrace() errors.Frames {
 // implements StackTracer and returns both.
 //
 // If nil is passed then nil is returned.
+//
+//go:noinline
 func WithStackTrace(err error, skipFrames int) (StackTracer, error) {
 	if err == nil {
 		return nil, nil

--- a/zerolog/zerolog.go
+++ b/zerolog/zerolog.go
@@ -16,26 +16,23 @@ import (
 	"github.com/secureworks/logger/log"
 )
 
-func errorStackMarshaler(skipLogFrameCount int) func(err error) interface{} {
-	return func(err error) interface{} {
-		if err == nil {
-			return nil
-		}
-		st, _ := common.WithStackTrace(err, skipLogFrameCount)
-		return st.StackTrace()
+var skipLogFrameCount = zerolog.CallerSkipFrameCount + 1
+
+//go:noinline
+func errorStackMarshaler(err error) interface{} {
+	if err == nil {
+		return nil
 	}
+	st, _ := common.WithStackTrace(err, skipLogFrameCount)
+	return st.StackTrace()
 }
 
 // Register logger.
 func init() {
-	// As we add another layer of indirection, we need to skip one more than
-	// the zerolog's default
-	var skipLogFrameCount = zerolog.CallerSkipFrameCount + 1
-
 	// These are package vars in Zerolog so putting them here is less race-y
 	// than setting them in newLogger.
 	zerolog.ErrorStackFieldName = log.StackField
-	zerolog.ErrorStackMarshaler = errorStackMarshaler(skipLogFrameCount)
+	zerolog.ErrorStackMarshaler = errorStackMarshaler
 
 	log.Register("zerolog", newLogger)
 }

--- a/zerolog/zerolog.go
+++ b/zerolog/zerolog.go
@@ -16,6 +16,17 @@ import (
 	"github.com/secureworks/logger/log"
 )
 
+func errorStackMarshaler(skipLogFrameCount int) func(err error) interface{} {
+	//go:noinline
+	return func(err error) interface{} {
+		if err == nil {
+			return nil
+		}
+		st, _ := common.WithStackTrace(err, skipLogFrameCount)
+		return st.StackTrace()
+	}
+}
+
 // Register logger.
 func init() {
 	// As we add another layer of indirection, we need to skip one more than
@@ -25,10 +36,7 @@ func init() {
 	// These are package vars in Zerolog so putting them here is less race-y
 	// than setting them in newLogger.
 	zerolog.ErrorStackFieldName = log.StackField
-	zerolog.ErrorStackMarshaler = func(err error) interface{} {
-		st, _ := common.WithStackTrace(err, skipLogFrameCount)
-		return st.StackTrace()
-	}
+	zerolog.ErrorStackMarshaler = errorStackMarshaler(skipLogFrameCount)
 
 	log.Register("zerolog", newLogger)
 }

--- a/zerolog/zerolog.go
+++ b/zerolog/zerolog.go
@@ -17,7 +17,6 @@ import (
 )
 
 func errorStackMarshaler(skipLogFrameCount int) func(err error) interface{} {
-	//go:noinline
 	return func(err error) interface{} {
 		if err == nil {
 			return nil

--- a/zerolog/zerolog_test.go
+++ b/zerolog/zerolog_test.go
@@ -113,4 +113,7 @@ func TestZerolog_Errors(t *testing.T) {
 
 	// Metadata fields.
 	testutils.AssertEqual(t, testFieldValue, fields.Meta)
+
+	// Nil error stack trace.
+	testutils.AssertNotPanics(t, func() { logger.WithError(nil).Msg("done") })
 }


### PR DESCRIPTION
Fixes #35.

Also adds noinline pragma, to ensure consistent number of trace frames skipped. This will require a follow up to bump tags.